### PR TITLE
update gradle 6 -> 8

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: gradle/wrapper-validation-action@v1
       - run: ./gradlew build
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: asciinema-vsync.jar
           path: build/asciinema-vsync.jar

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	dependencies {
-		classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.10'
+		classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.25'
 	}
 }
 
@@ -17,14 +17,14 @@ dependencies {
 	testImplementation 'junit:junit:4.13'
 	testImplementation 'com.google.truth:truth:1.0.1'
 
-	r8 'com.android.tools:r8:2.0.99'
+	r8 'com.android.tools:r8:8.5.35'
 }
 
 def fatJarProvider = tasks.register('fatJar', Jar) { task ->
 	task.dependsOn(configurations.named('runtimeClasspath'))
 	task.dependsOn(tasks.named('jar'))
 
-	task.classifier 'fat'
+	task.archiveClassifier = 'fat'
 
 	task.manifest {
 		attributes 'Main-Class': 'com.jakewharton.asciinema.vsync.-Main'
@@ -44,7 +44,7 @@ def fatJarProvider = tasks.register('fatJar', Jar) { task ->
 	}
 }
 
-def r8File = new File("$buildDir/libs/$archivesBaseName-r8.jar")
+def r8File = new File("$buildDir/libs/${base.archivesName.get()}-r8.jar")
 def r8RulesFile = file('src/main/rules.txt')
 def r8Jar = tasks.register('r8Jar', JavaExec) { task ->
 	task.dependsOn(configurations.named('runtimeClasspath'))
@@ -53,7 +53,7 @@ def r8Jar = tasks.register('r8Jar', JavaExec) { task ->
 	task.outputs.file(r8File)
 
 	task.classpath(configurations.r8)
-	task.main = 'com.android.tools.r8.R8'
+	task.mainClass = 'com.android.tools.r8.R8'
 	task.args = [
 		'--release',
 		'--classfile',
@@ -62,11 +62,11 @@ def r8Jar = tasks.register('r8Jar', JavaExec) { task ->
 		'--lib', System.properties['java.home'].toString()
 	]
 	doFirst {
-		task.args += fatJarProvider.get().archivePath
+		task.args += fatJarProvider.get().archiveFile.get()
 	}
 }
 
-def binaryFile = new File("$buildDir/${archivesBaseName}.jar")
+def binaryFile = new File("$buildDir/${base.archivesName.get()}.jar")
 def binaryJar = tasks.register('binaryJar') { task ->
 	task.dependsOn(r8Jar)
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
gradle versions below v7 have a number of vulnerabilities:

- CVE-2021-29429: [...]files created with open permissions in the system temporary directory can allow an attacker to access information downloaded by Gradle[...]

- CVE-2021-29427: [...]there is a vulnerability which can lead to information disclosure and/or dependency poisoning[...] In some cases, Gradle may ignore content filters and search all repositories for dependencies. This only occurs when repository content filtering is used from within a `pluginManagement` block in a settings file.

- CVE-2021-29428: [...]the system temporary directory can be created with open permissions that allow multiple users to create and delete files within it. Gradle builds could be vulnerable to a local privilege escalation from an attacker quickly deleting and recreating files in the system temporary directory.

- CVE-2021-32751: [...]start scripts generated by the `application` plugin and the `gradlew` script are both vulnerable to arbitrary code execution when an attacker is able to change environment variables for the user running the script[...]

This change updates gradle to v8 and additionally fixes gradle v9 deprecation warnings.